### PR TITLE
Align to manuscript

### DIFF
--- a/chapter4_001_messaging/src/main/scala/com/rarebooks/library/Librarian.scala
+++ b/chapter4_001_messaging/src/main/scala/com/rarebooks/library/Librarian.scala
@@ -106,7 +106,7 @@ class Librarian(findBookDuration: FiniteDuration) extends Actor with ActorLoggin
     case Done(e, s) =>
       process(e, s)
       unstashAll()
-      context.become(ready)
+      context.unbecome()
     case _ =>
       stash()
   }

--- a/chapter4_001_messaging/src/main/scala/com/rarebooks/library/RareBooks.scala
+++ b/chapter4_001_messaging/src/main/scala/com/rarebooks/library/RareBooks.scala
@@ -54,7 +54,7 @@ class RareBooks extends Actor with ActorLogging with Stash {
     case Close =>
       context.system.scheduler.scheduleOnce(closeDuration, self, Open)
       log.info("Closing down for the day")
-      context.become(close)
+      context.become(closed)
       self ! Report
   }
 
@@ -63,16 +63,16 @@ class RareBooks extends Actor with ActorLogging with Stash {
    *
    * @return partial function for completing the request.
    */
-  private def close: Receive = {
+  private def closed: Receive = {
+    case Report =>
+      totalRequests += requestsToday
+      log.info(s"$requestsToday requests processed today. Total requests processed = $totalRequests")
+      requestsToday = 0
     case Open =>
       context.system.scheduler.scheduleOnce(openDuration, self, Close)
       unstashAll()
       log.info("Time to open up!")
       context.become(open)
-    case Report =>
-      totalRequests += requestsToday
-      log.info(s"$requestsToday requests processed today. Total requests processed = $totalRequests")
-      requestsToday = 0
     case _ =>
       stash()
   }

--- a/chapter4_002_elasticity/src/main/scala/com/rarebooks/library/Librarian.scala
+++ b/chapter4_002_elasticity/src/main/scala/com/rarebooks/library/Librarian.scala
@@ -107,7 +107,7 @@ class Librarian(findBookDuration: FiniteDuration) extends Actor with ActorLoggin
     case Done(e, s) =>
       process(e, s)
       unstashAll()
-      context.become(ready)
+      context.unbecome()
     case _ =>
       stash()
   }

--- a/chapter4_002_elasticity/src/main/scala/com/rarebooks/library/RareBooks.scala
+++ b/chapter4_002_elasticity/src/main/scala/com/rarebooks/library/RareBooks.scala
@@ -57,7 +57,7 @@ class RareBooks extends Actor with ActorLogging with Stash {
     case Close =>
       context.system.scheduler.scheduleOnce(closeDuration, self, Open)
       log.info("Closing down for the day")
-      context.become(close)
+      context.become(closed)
       self ! Report
   }
 
@@ -66,16 +66,16 @@ class RareBooks extends Actor with ActorLogging with Stash {
    *
    * @return partial function for completing the request.
    */
-  private def close: Receive = {
+  private def closed: Receive = {
+    case Report =>
+      totalRequests += requestsToday
+      log.info(s"$requestsToday requests processed today. Total requests processed = $totalRequests")
+      requestsToday = 0
     case Open =>
       context.system.scheduler.scheduleOnce(openDuration, self, Close)
       unstashAll()
       log.info("Time to open up!")
       context.become(open)
-    case Report =>
-      totalRequests += requestsToday
-      log.info(s"$requestsToday requests processed today. Total requests processed = $totalRequests")
-      requestsToday = 0
     case _ =>
       stash()
   }

--- a/chapter4_003_faulty/src/main/scala/com/rarebooks/library/Librarian.scala
+++ b/chapter4_003_faulty/src/main/scala/com/rarebooks/library/Librarian.scala
@@ -113,7 +113,7 @@ class Librarian(findBookDuration: FiniteDuration, maxComplainCount: Int) extends
     case Done(e, s) =>
       process(e, s)
       unstashAll()
-      context.become(ready)
+      context.unbecome()
     case _ =>
       stash()
   }

--- a/chapter4_003_faulty/src/main/scala/com/rarebooks/library/RareBooks.scala
+++ b/chapter4_003_faulty/src/main/scala/com/rarebooks/library/RareBooks.scala
@@ -59,7 +59,7 @@ class RareBooks extends Actor with ActorLogging with Stash {
     case Close =>
       context.system.scheduler.scheduleOnce(closeDuration, self, Open)
       log.info("Closing down for the day")
-      context.become(close)
+      context.become(closed)
       self ! Report
   }
 
@@ -68,16 +68,16 @@ class RareBooks extends Actor with ActorLogging with Stash {
    *
    * @return partial function for completing the request.
    */
-  private def close: Receive = {
+  private def closed: Receive = {
+    case Report =>
+      totalRequests += requestsToday
+      log.info(s"$requestsToday requests processed today. Total requests processed = $totalRequests")
+      requestsToday = 0
     case Open =>
       context.system.scheduler.scheduleOnce(openDuration, self, Close)
       unstashAll()
       log.info("Time to open up!")
       context.become(open)
-    case Report =>
-      totalRequests += requestsToday
-      log.info(s"$requestsToday requests processed today. Total requests processed = $totalRequests")
-      requestsToday = 0
     case _ =>
       stash()
   }


### PR DESCRIPTION
Renamed function "close" to "closed" for readability
Demonstrate unbecome() to get out of busy state
Switch order of Report match to simplify typesetting error layout